### PR TITLE
Swap if avatar not found in admin panel

### DIFF
--- a/templates/admin/home.html
+++ b/templates/admin/home.html
@@ -57,7 +57,8 @@
             <div class="blockdata">
                 {% for user in recentusers %}
                 <a href="/u/{{ user.id }}" class="user-block{% if user.priv == 1 %} unverified{% endif %}">
-                    <img src="https://a.{{ domain() }}/{{ user.id }}" class="avatar-picture">
+                    <img src="https://a.{{ domain() }}/{{ user.id }}" class="avatar-picture"
+                         onerror="this.src='/static/images/avatar_notwork.png';">
                     <div class="user-stats"><span class="user-title">
                         <img src="/static/images/flags/{{ user.country|upper }}.png" class="profile-flag"> {{ user.name }}
                         </span><span class="user-artist">


### PR DESCRIPTION
Swapping avatar to avatar_notwork.png, if avatar wasn't found for user which sometimes might happen.