### PR TITLE
add clicking into a user's profile from the leaderboards, with data from the currently selected leaderboard mode

### DIFF
--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -83,7 +83,7 @@
                                         <% flags[user.country.toUpperCase()] %>
                                     </div>
                                 </a>
-                                <a :href="'/u/'+user.player_id">
+                                <a :href="'/u/'+user.player_id+'?mode='+mode+'&mods='+mods">
                                     <% user.name %>
                                 </a>
                             </td>


### PR DESCRIPTION
previous functionality: would always default to osu! standard, no matter what mode the leaderboard was in

![gif of proposed functionality](https://cdn.discordapp.com/attachments/931342797313802281/1056801848033562624/chrome_OQYwBBWyLh.gif)

sorry for the verbose title