### PR TITLE
introduce hacky fix to score time on user profiles

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -28,7 +28,8 @@
                         </div>
                         <div class="map-date">
                             <time>
-                                <% timeago.format(map.play_time) %>
+                                <!-- change '+01:00' to your server's current GMT code (UK is +1) -->
+                                <% moment(map.play_time + '+01:00').local().fromNow() %>
                             </time>
                         </div>
                     </div>
@@ -353,6 +354,7 @@
 
 {% block bottom %}
 <script src="/static/js/pages/profile.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
 {% if user['customisation']['banner'] == True or user['customisation']['background'] == True %}
 <style>
     {% if user['customisation']['banner'] == True %}


### PR DESCRIPTION
bpy should probably migrate to using utc unix timestamps to make this a lot easier, instead of just using the server's current time as a reference

closes #17 but at what cost